### PR TITLE
feat: add toast notifications

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "../styles/globals.css";
 import AffiliateDisclosure from "@/components/AffiliateDisclosure";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
+import { ToastProvider } from "@/components/Toast";
 
 export const metadata: Metadata = {
   title: {
@@ -30,10 +31,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="min-h-dvh bg-[#0b0c14] text-white antialiased">
-        <AffiliateDisclosure />
-        <SiteHeader />
-        <div className="mx-auto max-w-6xl px-4 py-8 md:py-12">{children}</div>
-        <SiteFooter />
+        <ToastProvider>
+          <AffiliateDisclosure />
+          <SiteHeader />
+          <div className="mx-auto max-w-6xl px-4 py-8 md:py-12">{children}</div>
+          <SiteFooter />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -3,13 +3,15 @@ import { useState } from "react";
 import { createUserWithEmailAndPassword, sendEmailVerification, signInWithEmailAndPassword } from "firebase/auth";
 import { auth, db } from "@/lib/firebase";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import { useToast } from "./Toast";
 
 export default function AuthModal({ onClose }:{ onClose:()=>void }) {
   const [mode, setMode] = useState<"signup" | "login">("signup");
-  const [email, setEmail] = useState(""); 
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string|null>(null);
+  const toast = useToast();
 
   const handleSubmit = async (e:any) => {
     e.preventDefault(); setError(null); setLoading(true);
@@ -18,13 +20,14 @@ export default function AuthModal({ onClose }:{ onClose:()=>void }) {
         const cred = await createUserWithEmailAndPassword(auth, email, password);
         await sendEmailVerification(cred.user);
         await setDoc(doc(db, "users", cred.user.uid), { email, createdAt: serverTimestamp() });
-        alert("Check your email for a verification link.");
+        toast("Check your email for a verification link.");
       } else {
         await signInWithEmailAndPassword(auth, email, password);
       }
       onClose();
     } catch (err:any) {
       setError(err.message);
+      toast(err.message, "error");
     } finally { setLoading(false); }
   };
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -2,6 +2,7 @@
 import { db } from "@/lib/firebase";
 import { useAuth } from "./AuthProvider";
 import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { useToast } from "./Toast";
 
 type Product = {
   id: string;
@@ -16,6 +17,7 @@ type Product = {
 
 export default function ProductCard({ p }: { p: Product }) {
   const { user } = useAuth();
+  const toast = useToast();
 
   const priceNum =
     typeof p.price === "number"
@@ -26,16 +28,20 @@ export default function ProductCard({ p }: { p: Product }) {
 
   const saveState = async (state: "own" | "want") => {
     if (!user) {
-      alert("Create a free account to save.");
+      toast("Create a free account to save.", "error");
       return;
     }
     const ref = doc(collection(db, `userProducts/${user.uid}/items`), p.id);
-    await setDoc(
-      ref,
-      { state, addedAt: serverTimestamp(), productId: p.id },
-      { merge: true }
-    );
-    alert(`Saved as ${state}`);
+    try {
+      await setDoc(
+        ref,
+        { state, addedAt: serverTimestamp(), productId: p.id },
+        { merge: true }
+      );
+      toast(`Saved as ${state}`);
+    } catch (err: any) {
+      toast("Failed to save. Please try again.", "error");
+    }
   };
 
   return (

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { createContext, ReactNode, useContext, useState } from "react";
+
+type Toast = { id: number; message: string; type: "success" | "error" };
+
+const ToastCtx = createContext<(msg: string, type?: Toast["type"]) => void>(() => {});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const remove = (id: number) => setToasts((prev) => prev.filter((t) => t.id !== id));
+
+  const toast = (message: string, type: Toast["type"] = "success") => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => remove(id), 3000);
+  };
+
+  return (
+    <ToastCtx.Provider value={toast}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`px-4 py-2 rounded shadow text-sm bg-[#1f2331] border ${
+              t.type === "error" ? "border-red-400 text-red-400" : "border-green-400 text-green-400"
+            }`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastCtx.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastCtx);


### PR DESCRIPTION
## Summary
- add lightweight ToastProvider with useToast hook
- surface save and auth actions via non-blocking toasts
- handle async errors through toast notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4a90934832a89540b208352f694