### PR TITLE
Handle Firestore fetch failures with loading and error states

### DIFF
--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -8,17 +8,39 @@ type Product = any;
 
 export default function ProductsPage() {
   const [items, setItems] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     (async () => {
-      const snap = await getDocs(collection(db, "products"));
-      const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-      setItems(list);
+      setLoading(true);
+      setError(null);
+      try {
+        const snap = await getDocs(collection(db, "products"));
+        const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setItems(list);
+      } catch (e: any) {
+        console.error(e);
+        setError(e?.message || "Failed to load products.");
+      } finally {
+        setLoading(false);
+      }
     })();
   }, []);
 
+  if (loading) {
+    return <p className="opacity-80">Loading products…</p>;
+  }
+
+  if (error) {
+    return <p className="text-red-400">{error}</p>;
+  }
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-      {items.map((p:any) => <ProductCard key={p.id} p={p}/>)}
+      {items.map((p: any) => (
+        <ProductCard key={p.id} p={p} />
+      ))}
     </div>
   );
 }

--- a/components/LandingSearch.tsx
+++ b/components/LandingSearch.tsx
@@ -37,13 +37,21 @@ export default function LandingSearch() {
   const [allProducts, setAllProducts] = useState<Product[]>([]);
   const [qStr, setQStr] = useState("");
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
+      setLoading(true);
+      setError(null);
       try {
         const snap = await getDocs(query(collection(db, "products"), limit(400)));
-        const items: Product[] = snap.docs.map((d) => normalizeDoc(d.id, d.data() as FirestoreProduct));
+        const items: Product[] = snap.docs.map((d) =>
+          normalizeDoc(d.id, d.data() as FirestoreProduct)
+        );
         setAllProducts(items);
+      } catch (e: any) {
+        console.error(e);
+        setError(e?.message || "Failed to load products.");
       } finally {
         setLoading(false);
       }
@@ -85,7 +93,9 @@ export default function LandingSearch() {
         </p>
       </div>
 
-      {qStr.trim().length >= 2 && (
+      {error && <p className="mt-4 text-red-400">{error}</p>}
+
+      {qStr.trim().length >= 2 && !error && (
         <div className="mt-6">
           {loading ? (
             <p className="text-white/70">Loading products…</p>


### PR DESCRIPTION
## Summary
- handle Firestore errors in product listing and landing search
- add loading and error states with user-facing fallback messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4a8ceb0832aa7c02d4eed5013b9