### PR TITLE
feat: add shared product interface

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -14,21 +14,12 @@ import {
   setDoc,
   Timestamp,
 } from "firebase/firestore";
+import type { Product } from "@/types/product";
 
 type UserItem = {
   productId: string;
   state: "own" | "want";
   addedAt?: Timestamp;
-};
-type Product = {
-  id: string;
-  brand: string;
-  name: string;
-  price?: number | string;
-  image_url?: string;
-  product_url_sephora?: string;
-  product_url_ulta?: string;
-  product_url_amazon?: string;
 };
 
 export default function MyStuffPage() {
@@ -59,7 +50,7 @@ export default function MyStuffPage() {
         const snap = await getDocs(query(itemsRef, orderBy("addedAt", "desc")));
         const saves: UserItem[] = snap.docs.map((d) => ({
           productId: d.id,
-          ...(d.data() as any),
+          ...(d.data() as Omit<UserItem, "productId">),
         }));
 
         const products = await Promise.all(
@@ -68,16 +59,16 @@ export default function MyStuffPage() {
             if (!pSnap.exists()) return null;
             return {
               id: pSnap.id,
-              ...(pSnap.data() as any),
+              ...(pSnap.data() as Omit<Product, "id">),
               _state: it.state,
             } as Product & { _state: "own" | "want" };
           })
         );
 
-        setItems(products.filter(Boolean) as any[]);
-      } catch (e: any) {
+        setItems(products.filter(Boolean) as (Product & { _state: "own" | "want" })[]);
+      } catch (e: unknown) {
         console.error(e);
-        setError(e?.message || "Failed to load your items.");
+        setError((e as { message?: string })?.message || "Failed to load your items.");
       } finally {
         setLoading(false);
       }

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -3,22 +3,26 @@ import { useEffect, useState } from "react";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import ProductCard from "@/components/ProductCard";
-
-type Product = any;
+import type { Product } from "@/types/product";
 
 export default function ProductsPage() {
   const [items, setItems] = useState<Product[]>([]);
   useEffect(() => {
     (async () => {
       const snap = await getDocs(collection(db, "products"));
-      const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      const list: Product[] = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as Omit<Product, "id">),
+      }));
       setItems(list);
     })();
   }, []);
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-      {items.map((p:any) => <ProductCard key={p.id} p={p}/>)}
+      {items.map((p) => (
+        <ProductCard key={p.id} p={p} />
+      ))}
     </div>
   );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -2,17 +2,7 @@
 import { db } from "@/lib/firebase";
 import { useAuth } from "./AuthProvider";
 import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
-
-type Product = {
-  id: string;
-  brand: string;
-  name: string;
-  price?: number | string;    // <— allow string or number
-  image_url?: string;
-  product_url_sephora?: string;
-  product_url_ulta?: string;
-  product_url_amazon?: string;
-};
+import type { Product } from "@/types/product";
 
 export default function ProductCard({ p }: { p: Product }) {
   const { user } = useAuth();

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,0 +1,14 @@
+export interface Product {
+  id: string;
+  brand: string;
+  name: string;
+  price?: number | string;
+  image_url?: string;
+  product_url_sephora?: string;
+  product_url_ulta?: string;
+  product_url_amazon?: string;
+  category?: string;
+  currency?: string;
+  slug?: string;
+  tags?: string | string[];
+}


### PR DESCRIPTION
## Summary
- add shared Product interface and import across product components
- map Firestore data to typed Product objects instead of using `any`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4a81590832a862197d6dd25b52a